### PR TITLE
Updating entry point name to not break inventory format

### DIFF
--- a/nornir_napalm/connections/__init__.py
+++ b/nornir_napalm/connections/__init__.py
@@ -6,7 +6,7 @@ from nornir.core.configuration import Config
 from nornir.core.connections import ConnectionPlugin
 
 
-CONNECTION_NAME = "nornir_napalm.napalm"
+CONNECTION_NAME = "napalm"
 
 
 class Napalm(ConnectionPlugin):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["David Barroso <dbarrosop@dravetech.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.plugins."nornir.plugins.connections"]
-"nornir_napalm.napalm" = "nornir_napalm.connections:Napalm"
+"napalm" = "nornir_napalm.connections:Napalm"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Entry point name was breaking existing code for both inventory format:

```
connection_options:
    napalm:
        extras:
```

And custom task definitions that created new connections:

```
    napalm = task.host.get_connection("napalm", task.nornir.config)
```

I didn't update any docs/tests as I wanted to bring it up before spending time on that.