### PR TITLE
Remove "None" default for source of napalm_ping

### DIFF
--- a/nornir_napalm/plugins/tasks/napalm_ping.py
+++ b/nornir_napalm/plugins/tasks/napalm_ping.py
@@ -7,7 +7,7 @@ from nornir_napalm.plugins.connections import CONNECTION_NAME
 def napalm_ping(
     task: Task,
     dest: str,
-    source: Optional[str] = None,
+    source: Optional[str] = "",
     ttl: Optional[int] = 255,
     timeout: Optional[int] = 2,
     size: Optional[int] = 100,


### PR DESCRIPTION
Fixed the same issue as seen in the main nornir napalm_ping module regarding a "None" source