### PR TITLE
Add revert_in parameter to napalm_configure (replaces #32)

### DIFF
--- a/nornir_napalm/plugins/tasks/napalm_configure.py
+++ b/nornir_napalm/plugins/tasks/napalm_configure.py
@@ -44,9 +44,9 @@ def napalm_configure(
     dry_run = task.is_dry_run(dry_run)
     if not dry_run and diff:
         if commit_message:
-            device.commit_config(message=commit_message)
+            device.commit_config(message=commit_message, revert_in=revert_in)
         else:
-            device.commit_config()
+            device.commit_config(revert_in=revert_in)
     else:
         device.discard_config()
     return Result(host=task.host, diff=diff, changed=len(diff) > 0)

--- a/nornir_napalm/plugins/tasks/napalm_configure.py
+++ b/nornir_napalm/plugins/tasks/napalm_configure.py
@@ -12,6 +12,8 @@ def napalm_configure(
     configuration: Optional[str] = None,
     replace: bool = False,
     commit_message: str = None,
+    revert_in: Optional[int] = None,
+    confirm_commit: bool = False,
 ) -> Result:
     """
     Loads configuration into a network devices using napalm
@@ -21,6 +23,8 @@ def napalm_configure(
         filename: filename containing the configuration to load into the device
         configuration: configuration to load into the device
         replace: whether to replace or merge the configuration
+        revert_in: amount of time in seconds after which to revert the commit, None to disable
+        confirm_commit: can be set to True to allow confirming of a commit that is pending revert
 
     Returns:
         Result object with the following attributes set:
@@ -29,7 +33,9 @@ def napalm_configure(
     """
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
 
-    if replace:
+    if confirm_commit:
+        device.confirm_commit()
+    elif replace:
         device.load_replace_candidate(filename=filename, config=configuration)
     else:
         device.load_merge_candidate(filename=filename, config=configuration)


### PR DESCRIPTION
Extends what was proposed in #32 but adds the ability to confirm a commit that was sent previously with a revert_in timer.