### PR TITLE
pass encoding to napalm_cli for eos

### DIFF
--- a/nornir_napalm/plugins/tasks/napalm_cli.py
+++ b/nornir_napalm/plugins/tasks/napalm_cli.py
@@ -5,7 +5,7 @@ from nornir.core.task import Result, Task
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
 
-def napalm_cli(task: Task, commands: List[str]) -> Result:
+def napalm_cli(task: Task, commands: List[str], encoding: 'text') -> Result:
     """
     Run commands on remote devices using napalm
 
@@ -17,5 +17,8 @@ def napalm_cli(task: Task, commands: List[str]) -> Result:
         * result (``dict``): result of the commands execution
     """
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
-    result = device.cli(commands)
+    if task.host.platform == 'eos':
+      result = device.cli(commands, encoding=encoding)
+    else:
+      result = device.cli(command)
     return Result(host=task.host, result=result)

--- a/nornir_napalm/plugins/tasks/napalm_cli.py
+++ b/nornir_napalm/plugins/tasks/napalm_cli.py
@@ -4,21 +4,22 @@ from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
-
-def napalm_cli(task: Task, commands: List[str], encoding: 'text') -> Result:
+def napalm_cli(task: Task, commands: List[str], encoding: str = "text") -> Result:
     """
     Run commands on remote devices using napalm
 
     Arguments:
       commands: commands to execute
-
+      encoding: pass 'text' or 'json' to napalm cli
     Returns:
       Result object with the following attributes set:
         * result (``dict``): result of the commands execution
     """
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
-    if task.host.platform == 'eos':
+    
+    if task.host.platform == "eos":
       result = device.cli(commands, encoding=encoding)
     else:
-      result = device.cli(command)
+      result = device.cli(commands)
+
     return Result(host=task.host, result=result)

--- a/nornir_napalm/plugins/tasks/napalm_cli.py
+++ b/nornir_napalm/plugins/tasks/napalm_cli.py
@@ -1,25 +1,21 @@
-from typing import List
+from typing import Any, List
 
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
-def napalm_cli(task: Task, commands: List[str], encoding: str = "text") -> Result:
+
+def napalm_cli(task: Task, commands: List[str], **kwargs: Any) -> Result:
     """
     Run commands on remote devices using napalm
 
     Arguments:
-      commands: commands to execute
-      encoding: pass 'text' or 'json' to napalm cli
+    commands: commands to execute
+      **kwargs: placeholder for user added arguments
     Returns:
       Result object with the following attributes set:
         * result (``dict``): result of the commands execution
     """
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
-    
-    if task.host.platform == "eos":
-      result = device.cli(commands, encoding=encoding)
-    else:
-      result = device.cli(commands)
-
+    result = device.cli(commands, **kwargs)
     return Result(host=task.host, result=result)


### PR DESCRIPTION
In regards to Issue #50, need to ability to toggle between 'text' and 'json' encoding for EOS platform.