### PR TITLE
chore: add Python 3.14 to support matrix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,6 +34,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     steps:
       - uses: actions/checkout@v7
       - name: Install uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "napalm>=5,<6",


### PR DESCRIPTION
## Summary
Declares support for Python 3.14 so users on the latest interpreter get a
supported, CI-verified release.

## Key Changes
- CI test matrix now runs against Python 3.14
- `Programming Language :: Python :: 3.14` trove classifier added

## Related Context
Cherry-pick of 027d844 (nornir-automation/nornir_napalm#107), which landed on
`master` — this brings it to `main`.

## Test Plan
Watch the CI matrix; the new 3.14 job must pass alongside 3.10–3.13.