### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.6.0] - 2026-08-02
+
+### Changed
+
+- **Dropped support for Python 3.8 and 3.9.** The minimum supported version is now Python 3.10.
+- Added Python 3.13 and 3.14 to the supported versions (3.10 - 3.14).
+- Migrated packaging and dependency management from Poetry to [uv](https://docs.astral.sh/uv/),
+  using the `uv_build` backend. Nothing changes for consumers installing from PyPI.
+- Replaced `black` and `pylama` with [ruff](https://docs.astral.sh/ruff/) for formatting and
+  linting. Source files were reformatted accordingly (no behaviour change).
+
+### Added
+
+- `py.typed` marker, so type checkers now pick up the inline type annotations shipped with the
+  package ([#85](https://github.com/nornir-automation/nornir_napalm/pull/85)).
+
+### Fixed
+
+- Refreshed the CI workflows, `Makefile` and `Dockerfile` to build and test against the current
+  Python versions.
+- Numerous transitive development dependency bumps.
+
+[0.6.0]: https://github.com/nornir-automation/nornir_napalm/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [0.6.0] - 2026-08-02
+## [0.6.0] - 2026-08-03
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nornir_napalm"
-version = "0.5.0"
+version = "0.6.0"
 description = "NAPALM's plugins for nornir"
 authors = [{ name = "David Barroso", email = "dbarrosop@dravetech.com" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1722,7 +1722,7 @@ wheels = [
 
 [[package]]
 name = "nornir-napalm"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "napalm" },


### PR DESCRIPTION
## Summary

Cuts the 0.6.0 release and gives the project a root `CHANGELOG.md` it has never had. Users upgrading from 0.5.0 get an explicit, readable statement of what changed — most importantly that Python 3.8 and 3.9 are no longer supported.

## Key Changes

- Version bumped to `0.6.0` in `pyproject.toml` (and the matching `uv.lock` entry).
- New root `CHANGELOG.md` documenting the 0.6.0 release: Python 3.10–3.14 support (3.8/3.9 dropped), the Poetry→uv migration, the black/pylama→ruff switch, and the `py.typed` marker that makes the package's type hints visible to type checkers.

## Test Plan

- `make tests` (ruff format, ruff check, mypy, pytest) — CI runs the same.
- `uv build` produces `nornir_napalm-0.6.0` artifacts.

Note: the changelog covers 0.6.0 only; 0.1.0–0.5.0 history is not back-filled.