### PR TITLE
Modernize type annotations to PEP 585/604 syntax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 import sys
-from typing import List
 
 sys.path.insert(0, "../")
 
@@ -41,7 +40,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/nornir_napalm/plugins/connections/__init__.py
+++ b/nornir_napalm/plugins/connections/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from napalm import get_network_driver
 
@@ -23,17 +23,17 @@ class Napalm:
 
     def open(
         self,
-        hostname: Optional[str],
-        username: Optional[str],
-        password: Optional[str],
-        port: Optional[int],
-        platform: Optional[str],
-        extras: Optional[Dict[str, Any]] = None,
-        configuration: Optional[Config] = None,
+        hostname: str | None,
+        username: str | None,
+        password: str | None,
+        port: int | None,
+        platform: str | None,
+        extras: dict[str, Any] | None = None,
+        configuration: Config | None = None,
     ) -> None:
         extras = extras or {}
 
-        parameters: Dict[str, Any] = {
+        parameters: dict[str, Any] = {
             "hostname": hostname,
             "username": username,
             "password": password,

--- a/nornir_napalm/plugins/tasks/napalm_cli.py
+++ b/nornir_napalm/plugins/tasks/napalm_cli.py
@@ -1,11 +1,11 @@
-from typing import Any, List
+from typing import Any
 
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
 
-def napalm_cli(task: Task, commands: List[str], **kwargs: Any) -> Result:
+def napalm_cli(task: Task, commands: list[str], **kwargs: Any) -> Result:
     """
     Run commands on remote devices using napalm
 

--- a/nornir_napalm/plugins/tasks/napalm_configure.py
+++ b/nornir_napalm/plugins/tasks/napalm_configure.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Any
 
 from nornir.core.task import Result, Task
 from nornir_napalm.plugins.connections import CONNECTION_NAME
@@ -6,12 +6,12 @@ from nornir_napalm.plugins.connections import CONNECTION_NAME
 
 def napalm_configure(
     task: Task,
-    dry_run: Optional[bool] = None,
-    filename: Optional[str] = None,
-    configuration: Optional[str] = None,
+    dry_run: bool | None = None,
+    filename: str | None = None,
+    configuration: str | None = None,
     replace: bool = False,
-    commit_message: Optional[str] = None,
-    revert_in: Optional[int] = None,
+    commit_message: str | None = None,
+    revert_in: int | None = None,
 ) -> Result:
     """
     Loads configuration into a network devices using napalm
@@ -38,7 +38,7 @@ def napalm_configure(
 
     dry_run = task.is_dry_run(dry_run)
 
-    commit_kwargs: Dict[str, Any] = {}
+    commit_kwargs: dict[str, Any] = {}
     if commit_message:
         commit_kwargs["message"] = commit_message
     if revert_in is not None:

--- a/nornir_napalm/plugins/tasks/napalm_confirm_commit.py
+++ b/nornir_napalm/plugins/tasks/napalm_confirm_commit.py
@@ -1,10 +1,9 @@
-from typing import Optional
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
 
-def napalm_confirm_commit(task: Task, dry_run: Optional[bool] = None) -> Result:
+def napalm_confirm_commit(task: Task, dry_run: bool | None = None) -> Result:
     """
     Confirm a commit that has a "pending" commit via the revert_in argument to
     napalm_config.

--- a/nornir_napalm/plugins/tasks/napalm_get.py
+++ b/nornir_napalm/plugins/tasks/napalm_get.py
@@ -1,15 +1,15 @@
 import copy
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
-GetterOptionsDict = Optional[Dict[str, Dict[str, Any]]]
+GetterOptionsDict = dict[str, dict[str, Any]] | None
 
 
 def napalm_get(
-    task: Task, getters: List[str], getters_options: GetterOptionsDict = None, **kwargs: Any
+    task: Task, getters: list[str], getters_options: GetterOptionsDict = None, **kwargs: Any
 ) -> Result:
     """
     Gather information from network devices using napalm
@@ -36,7 +36,7 @@ def napalm_get(
     for g in getters:
         options = copy.deepcopy(kwargs)
         options.update(getters_options.get(g, {}))
-        getter = g if g.startswith("get_") else "get_{}".format(g)
+        getter = g if g.startswith("get_") else f"get_{g}"
         method = getattr(device, getter)
         result[g] = method(**options)
     return Result(host=task.host, result=result)

--- a/nornir_napalm/plugins/tasks/napalm_ping.py
+++ b/nornir_napalm/plugins/tasks/napalm_ping.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
@@ -7,12 +6,12 @@ from nornir_napalm.plugins.connections import CONNECTION_NAME
 def napalm_ping(
     task: Task,
     dest: str,
-    source: Optional[str] = "",
-    ttl: Optional[int] = 255,
-    timeout: Optional[int] = 2,
-    size: Optional[int] = 100,
-    count: Optional[int] = 5,
-    vrf: Optional[str] = None,
+    source: str | None = "",
+    ttl: int | None = 255,
+    timeout: int | None = 2,
+    size: int | None = 100,
+    count: int | None = 5,
+    vrf: str | None = None,
 ) -> Result:
     """
     Executes ping on the device and returns a dictionary with the result.

--- a/nornir_napalm/plugins/tasks/napalm_rollback.py
+++ b/nornir_napalm/plugins/tasks/napalm_rollback.py
@@ -1,10 +1,9 @@
-from typing import Optional
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
 
-def napalm_rollback(task: Task, dry_run: Optional[bool] = None) -> Result:
+def napalm_rollback(task: Task, dry_run: bool | None = None) -> Result:
     """
     Rollback device configuration using napalm
     Arguments:

--- a/nornir_napalm/plugins/tasks/napalm_validate.py
+++ b/nornir_napalm/plugins/tasks/napalm_validate.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from nornir.core.task import Result, Task
 
 from nornir_napalm.plugins.connections import CONNECTION_NAME
 
-ValidationSourceData = Optional[Dict[str, Dict[str, Any]]]
+ValidationSourceData = dict[str, dict[str, Any]] | None
 
 
 def napalm_validate(
     task: Task,
-    src: Optional[str] = None,
+    src: str | None = None,
     validation_source: ValidationSourceData = None,
 ) -> Result:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ line-ending = "auto"
 
 [tool.ruff.lint]
 # Port of the previous pylama linters: pep8 (E/W) + pyflakes (F) + mccabe (C90)
-select = ["E", "W", "F", "C90"]
+# UP (pyupgrade) keeps annotations on PEP 585/604 syntax now that we require >= 3.10
+select = ["E", "W", "F", "C90", "UP"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,9 @@ def nornir(request):
         inventory={
             "plugin": "SimpleInventory",
             "options": {
-                "host_file": "{}/inventory_data/hosts.yaml".format(dir_path),
-                "group_file": "{}/inventory_data/groups.yaml".format(dir_path),
-                "defaults_file": "{}/inventory_data/defaults.yaml".format(dir_path),
+                "host_file": f"{dir_path}/inventory_data/hosts.yaml",
+                "group_file": f"{dir_path}/inventory_data/groups.yaml",
+                "defaults_file": f"{dir_path}/inventory_data/defaults.yaml",
             },
         },
         dry_run=True,

--- a/tests/unit/test_napalm_configure.py
+++ b/tests/unit/test_napalm_configure.py
@@ -24,7 +24,7 @@ def connect(task, extras):
     )
 
 
-class Test(object):
+class Test:
     def test_napalm_configure_change_dry_run(self, nornir):
         opt = {"path": THIS_DIR + "/test_napalm_configure_change_dry_run"}
         configuration = "hostname changed-hostname"

--- a/tests/unit/test_napalm_confirm_commit.py
+++ b/tests/unit/test_napalm_confirm_commit.py
@@ -23,7 +23,7 @@ def set_pending_commit(task):
     conn._pending_commits = True
 
 
-class Test(object):
+class Test:
     def test_napalm_confirm_commit_no_pending(self, nornir):
         d = nornir.filter(name="dev3.group_2")
         d.run(connect, extras={})

--- a/tests/unit/test_napalm_get.py
+++ b/tests/unit/test_napalm_get.py
@@ -18,7 +18,7 @@ def connect(task, extras):
     )
 
 
-class Test(object):
+class Test:
     def test_napalm_getters(self, nornir):
         opt = {"path": THIS_DIR + "/test_napalm_getters"}
         d = nornir.filter(name="dev3.group_2")

--- a/tests/unit/test_napalm_rollback.py
+++ b/tests/unit/test_napalm_rollback.py
@@ -17,7 +17,7 @@ def connect(task, extras):
     )
 
 
-class Test(object):
+class Test:
     def test_napalm_rollback_commit(self, nornir):
         opt = {"path": THIS_DIR + "/test_napalm_rollback_commit"}
         d = nornir.filter(name="dev3.group_2")

--- a/tests/unit/test_napalm_validate.py
+++ b/tests/unit/test_napalm_validate.py
@@ -18,7 +18,7 @@ def connect(task, extras):
     )
 
 
-class Test(object):
+class Test:
     def test_napalm_validate_src_ok(self, nornir):
         opt = {"path": THIS_DIR + "/mocked/napalm_get/test_napalm_getters"}
         d = nornir.filter(name="dev3.group_2")


### PR DESCRIPTION
## Summary

The codebase still annotated types with the legacy `typing` aliases (`Dict`, `List`,
`Optional`) even though the project requires Python >= 3.10. Contributors now read and
write the same annotation syntax they see everywhere else in modern Python, and the
linter keeps it that way instead of relying on review to catch regressions.

## Key Changes

- Annotations across the plugins, `docs/source/conf.py`, and the tests use builtin
  generics (PEP 585) and the `X | None` union operator (PEP 604).
- Ruff's `UP` (pyupgrade) rules are enabled, so legacy spellings now fail CI rather
  than slipping back in.
- Public plugin signatures are semantically unchanged — `Optional[str]` and
  `str | None` are the same type, so callers are unaffected.

## Related Context

Fixes #109.

## Documentation Updates

None. The Sphinx docs are autodoc-driven from docstrings, and no docstrings changed.

## Test Plan

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy nornir_napalm` — no issues found
- `uv run pytest` — 19 passed

## Note for reviewers

Enabling `UP` wholesale also swept two modernizations beyond PEP 585/604:
`"{}".format()` → f-strings (`napalm_get.py`, `tests/conftest.py`) and
`class Test(object)` → `class Test` in five unit test files. Happy to narrow the ruff
selection if you'd rather keep those out.
